### PR TITLE
chore(): automatically label new issues with post-FF label

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -10,3 +10,15 @@ jobs:
     with:
       project_id: 2
     secrets: inherit
+
+  # add post-FF label to every new issue, to track issues discovered after FF
+  # This is temporary and it will be removed after the release
+  add-post-ff-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: |
+          gh issue --repo ${{github.repository}} edit ${{github.event.issue.number}} --add-label "post-FF"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Description

adds a job that labels every new issue with `post-FF` label to GitHub action that this triggers for every new issue.

This is to make it easier to track issues discovered after FF
It will be removed after the release.


## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
